### PR TITLE
Fix the problem which causes some courses to block the scheduler

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -12,6 +12,7 @@ module.exports = {
   },
   rules: {
     'no-console': process.env.NODE_ENV === 'production' ? 'warn' : 'off',
-    'no-debugger': process.env.NODE_ENV === 'production' ? 'warn' : 'off'
+    'no-debugger': process.env.NODE_ENV === 'production' ? 'warn' : 'off',
+    'no-constant-condition': process.env.NODE_ENV === 'production' ? 'warn' : 'off'
   }
 }

--- a/src/combinations.js
+++ b/src/combinations.js
@@ -1,10 +1,14 @@
-function find(allData, selected, filteredSections, filteredInstructors, filteredSlots) {
+function find(allData, selected, dummyCourses, filteredSections, filteredInstructors, filteredSlots) {
   let combinations = [];
 
   function calculate(sections, currentSchedule, index) {
-    if ( selected.length === 0) return
+    if ( selected.length === 0) {
+      if (dummyCourses.length !== 0) combinations.push(dummyCourses)
+      return
+    }
 
-    if (index === selected.length)  {
+    if (index === selected.length) {
+      if (dummyCourses.length !== 0) sections = sections.concat(dummyCourses)
       combinations.push(sections)
       return
     }


### PR DESCRIPTION
Recently, I have experienced a weird behavior that prevents me from getting a valid schedule if I include CS299 as a course. Later on, I realized that no matter which course I select, if one of the added courses does not have any lecture hours, the scheduler thinks that there is no valid schedule.

<img width="1440" alt="The scheduler assumes that CS319 and CS299 conflict, which is not the case." src="https://user-images.githubusercontent.com/25904864/188613790-88f7ee51-4f43-4125-8149-46f6d4f015ef.png">

Since I have had a hard time trying to observe the inadequate OOP & Design Patterns in the existing code base, I came up with a data-oriented solution for convenience with the rest of the project. According to that we evaluate the courses with zero lecture and lab hours as ``dummyCourses`` and execute the logic in this direction.

<img width="1440" alt="The scheduler works as expected." src="https://user-images.githubusercontent.com/25904864/188615906-d0f2c804-f6bb-4077-b7aa-694035e9e912.png">

The only downside is that because we append two arrays (``selectedCourses`` and ``dummyCourses``) when listing the courses, ``dummyCourses`` would always be pushed to the end in the UI without respecting the insertion order (check Selection Details at the bottom and labels at the top).